### PR TITLE
Fix binance module typo

### DIFF
--- a/src/model/integrations/BinanceWallet.js
+++ b/src/model/integrations/BinanceWallet.js
@@ -1,7 +1,7 @@
 import PromiseUtils from '../../PromiseUtils'
 import Coin from '../Coin'
 // noinspection NpmUsedModulesInstalled
-import Binance from 'Binance'
+import Binance from 'binance'
 
 const settings = require('../../../settings.json')
 


### PR DESCRIPTION
Hello,

Seem that there is a little typo in binance module that produces the next message:

```
Warning: Integration for Exchange: Binance not found!
```

This should fix it.

Thank you