### PR TITLE
Hide zero amount for binance

### DIFF
--- a/src/model/integrations/BinanceWallet.js
+++ b/src/model/integrations/BinanceWallet.js
@@ -27,7 +27,9 @@ export default class BinanceWallet extends AbstractWallet {
               let symbol = data.asset
               let amount = data.free
 
-              result.push(new Coin(symbol, amount, 'Binance'))
+              if (amount > 0) {
+                result.push(new Coin(symbol, amount, 'Binance'))
+              }
             }
             resolve(result)
           })


### PR DESCRIPTION
Binance includes zero amounts in the Api, this hides those. Otherwise it fills the empty rows with 'Binance'