### PR TITLE
Add blockchain/etherscan address checkers

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -1,5 +1,15 @@
 {
   "accounts": {
+    "blockchain": [{
+      "addresses": [
+        ""
+      ]
+    }],
+    "etherscan": [{
+      "addresses": [
+        ""
+      ]
+    }],
     "poloniex": [{
       "apiKey": "",
       "apiSecret": ""

--- a/src/model/integrations/BlockchainWallet.js
+++ b/src/model/integrations/BlockchainWallet.js
@@ -1,0 +1,33 @@
+import AbstractWallet from "./AbstractWallet";
+import Coin from '../Coin'
+import request from 'request-promise'
+
+export default class BlockchainWallet extends AbstractWallet {
+  /**
+   * Returns the Bitcoin balance for addresses
+   * @param addresses The Bitcoin wallet addressses.
+   * @return {Promise} The address balances.
+   */
+  static _getBalanceForCredential(credentials) {
+    return new Promise((resolve, reject) => {
+        let addresses = credentials.addresses.join('|')
+        let options = {
+          uri: 'https://blockchain.info/nl/multiaddr?limit=0&active=' + encodeURIComponent(addresses),
+          json: true
+        }
+        return request(options)
+          .then(data => {
+            let result = []
+            for (let address of data.addresses) {
+              let amount = address.final_balance / Math.pow(10,8)
+              result.push(new Coin('BTC', amount, 'Blockchain'))
+            }
+            resolve(result)
+          })
+          .catch(err => {
+            reject(err)
+          })
+      }
+    )
+  }
+}

--- a/src/model/integrations/EtherscanWallet.js
+++ b/src/model/integrations/EtherscanWallet.js
@@ -1,0 +1,33 @@
+import AbstractWallet from "./AbstractWallet";
+import Coin from '../Coin'
+import request from 'request-promise'
+
+export default class EtherscanWallet extends AbstractWallet {
+  /**
+   * Returns the Ether balance for addresses
+   * @param addresses The Bitcoin wallet addresss.
+   * @return {Promise} The address balances.
+   */
+  static _getBalanceForCredential(credentials) {
+    return new Promise((resolve, reject) => {
+        let addresses = credentials.addresses.join(',')
+        let options = {
+          uri: 'https://api.etherscan.io/api?module=account&action=balancemulti&address=' + encodeURIComponent(addresses),
+          json: true
+        }
+        return request(options)
+          .then(data => {
+            let result = []
+            for (let address of data.result) {
+              let amount = address.balance / Math.pow(10,18)
+              result.push(new Coin('ETH', amount, 'Etherscan'))
+            }
+            resolve(result)
+          })
+          .catch(err => {
+            reject(err)
+          })
+      }
+    )
+  }
+}

--- a/test/model/integrations/testBlockchainWallet.js
+++ b/test/model/integrations/testBlockchainWallet.js
@@ -1,0 +1,17 @@
+import assert from 'assert'
+import BlockchainWallet from "../../../src/model/integrations/BlockchainWallet";
+
+import * as Settings from './../../../src/Settings'
+
+describe('Testing Blockchain integration', () => {
+  before(function() {
+    if (!Settings.accounts.blockchain) {
+      this.skip()
+    }
+  })
+  it('Testing initial connection and balances', async () => {
+    let wallet = new BlockchainWallet(Settings.accounts.blockchain[0])
+    let balance = await wallet.getBalance()
+    assert(balance.length > 0)
+  })
+})

--- a/test/model/integrations/testEtherscanWallet.js
+++ b/test/model/integrations/testEtherscanWallet.js
@@ -1,0 +1,17 @@
+import assert from 'assert'
+import EtherscanWallet from "../../../src/model/integrations/EtherscanWallet";
+
+import * as Settings from './../../../src/Settings'
+
+describe('Testing Etherscan integration', () => {
+  before(function() {
+    if (!Settings.accounts.etherscan) {
+      this.skip()
+    }
+  })
+  it('Testing initial connection and balances', async () => {
+    let wallet = new EtherscanWallet(Settings.accounts.etherscan[0])
+    let balance = await wallet.getBalance()
+    assert(balance.length > 0)
+  })
+})


### PR DESCRIPTION
This adds integrations for addresses instead of APIs. They don't require API keys, but use addresses directly. Multiple can be used within the same call. Fixes #19