### PR TITLE
Formatting

### DIFF
--- a/src/Format.js
+++ b/src/Format.js
@@ -6,9 +6,10 @@ export default class Format {
       return ''
     }
     let formatter = new Intl.NumberFormat('en-US', {
-      minimumFractionDigits: 0
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
     })
-    return formatter.format(parseInt(number))
+    return formatter.format(parseFloat(number))
   }
 
   static percent(number) {
@@ -19,7 +20,7 @@ export default class Format {
   }
 
   static bitcoin(number, chars_) {
-    let chars = (chars_) ? chars_ : 2
+    let chars = (chars_) ? chars_ : 8
     if (!number) {
       return ''
     }

--- a/test/model/testFormat.js
+++ b/test/model/testFormat.js
@@ -3,18 +3,18 @@ import Format from './../../src/Format'
 
 describe('Testing formatter', () => {
   it('format.money', async () => {
-    assert(Format.money(1000) === '1,000')
+    assert(Format.money(1000) === '1,000.00')
     assert(Format.money(null) === '')
   })
   it('format.percent', async () => {
-    assert(Format.bitcoin(99.01) === '99.01')
-    assert(Format.bitcoin(1) === '1.00')
-    assert(Format.bitcoin(0.001) === '0.00')
-    assert(Format.bitcoin(null) === '')
+    assert(Format.percent(99.01) === '99.0')
+    assert(Format.percent(1) === '1.0')
+    assert(Format.percent(0.001) === '0.0')
+    assert(Format.percent(null) === '')
   })
   it('format.bitcoin', async () => {
-    assert(Format.bitcoin(1000.01) === '1000.01')
-    assert(Format.bitcoin(1000) === '1000.00')
+    assert(Format.bitcoin(0.123456789) === '0.12345679')
+    assert(Format.bitcoin(1) === '1.00000000')
     assert(Format.bitcoin(null) === '')
   })
   it('format.addPlusSign', async () => {


### PR DESCRIPTION
Needed more precision as some coins might just be a fraction of the total portfolio, but still need proper display. Don't know if everybody agrees... A more elegant solution would be to let users define the amount of decimals for fiat and crypto in the settings maybe. Implementation for this is tougher though due to `testFormat.js` ;-)