### PR TITLE
Integration of Ethplorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ CryptoETF has API integrations with the following exchanges:
 
 With these exchanges, you can easily build yourself your own CryptoETF.
 
+##APIs
+These APIs are used to monitor wallet addresses:
+- [Blockchain.info](https://blockchain.info/api/blockchain_api) for multiple BTC addresses
+- [Etherscan.io](https://etherscan.io/apis) for multiple ETH addresses
+- [Ethplorer.io](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) for a single ETH address including all tokens.
+
 ## Settings
 The tool expects your settings in settings.json. Take a look at settings.example.json for a starting point.
 - *accounts*: Under accounts, fill in your api credentials for the exchange that you want to use. Delete the exchanges that you do not need.

--- a/settings.example.json
+++ b/settings.example.json
@@ -10,6 +10,9 @@
         ""
       ]
     }],
+    "ethplorer": [{
+      "address": ""
+    }],
     "poloniex": [{
       "apiKey": "",
       "apiSecret": ""

--- a/src/model/integrations/EthplorerWallet.js
+++ b/src/model/integrations/EthplorerWallet.js
@@ -1,0 +1,36 @@
+import AbstractWallet from "./AbstractWallet";
+import Coin from '../Coin'
+import request from 'request-promise'
+
+export default class EtherscanWallet extends AbstractWallet {
+  /**
+   * Returns the Ether balance for addresses
+   * @param addresses The Bitcoin wallet addresss.
+   * @return {Promise} The address balances.
+   */
+  static _getBalanceForCredential(credentials) {
+    return new Promise((resolve, reject) => {
+      let options = {
+        uri: 'https://api.ethplorer.io/getAddressInfo/' + credentials.address + '?apiKey=freekey',
+        json: true
+      }
+      return request(options)
+        .then(data => {
+          let result = []
+          let amount = data.ETH.balance
+          result.push(new Coin('ETH', amount, 'Ethplorer'))
+          for (let token of data.tokens) {
+            let token_symbol = token.tokenInfo.symbol
+            let token_amount = Number(token.balance / Math.pow(10,token.tokenInfo.decimals))
+            if (token_symbol && token_amount) {
+              result.push(new Coin(token_symbol, token_amount, 'Ethplorer'))
+            }
+          }
+          resolve(result)
+      })
+      .catch(err => {
+        reject(err)
+      })
+    })
+  }
+}

--- a/test/model/integrations/testEthplorerWallet.js
+++ b/test/model/integrations/testEthplorerWallet.js
@@ -1,0 +1,17 @@
+import assert from 'assert'
+import EthplorerWallet from "../../../src/model/integrations/EthplorerWallet";
+
+import * as Settings from './../../../src/Settings'
+
+describe('Testing Ethplorer integration', () => {
+  before(function() {
+    if (!Settings.accounts.ethplorer) {
+      this.skip()
+    }
+  })
+  it('Testing initial connection and balances', async () => {
+    let wallet = new EthplorerWallet(Settings.accounts.ethplorer[0])
+    let balance = await wallet.getBalance()
+    assert(balance.length > 0)
+  })
+})


### PR DESCRIPTION
Ethplorer's API allows to check the balance of an Ethereum address **including** all tokens present. This integration adds all ETH and other tokens present on the address provided in `settings.json` to the portfolio.

Multiple addresses not yet supported.