### PR TITLE
fix(sample): reflect XRB symbol change on example

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -58,7 +58,8 @@
     "STR": "XLM",
     "IOTA": "MIOTA",
     "XBT": "BTC",
-    "XDG": "DOGE"
+    "XDG": "DOGE",
+    "NANO": "XRB"
   },
   "otherHoldings": [{
     "BCH": 1.0


### PR DESCRIPTION
CoinMarketCap API still calls it XRB but some exchange APIs (notably Binance) call it NANO after the [rebrand](https://hackernoon.com/nano-rebrand-announcement-9101528a7b76), so this makes the example settings file a bit easier to use