### PR TITLE
Filter ethereum transactions

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -8,6 +8,9 @@
     "etherscan": [{
       "addresses": [
         ""
+      ],
+      "from": [
+        ""
       ]
     }],
     "poloniex": [{

--- a/src/model/integrations/EtherscanWallet.js
+++ b/src/model/integrations/EtherscanWallet.js
@@ -10,6 +10,31 @@ export default class EtherscanWallet extends AbstractWallet {
    */
   static _getBalanceForCredential(credentials) {
     return new Promise((resolve, reject) => {
+      let addresses = credentials.addresses;
+
+      let result = [];
+      var promises = [];
+
+      if(typeof(credentials.from) != "undefined" ){
+        for (let address of addresses) {
+          promises.push(request({
+            uri: 'http://api.etherscan.io/api?module=account&action=txlist&address=' + address + '&sort=asc',
+            json: true
+          }).then((data2)=>{
+            let amount = 0;
+            for(let transaction of data2.result){
+              if(typeof(credentials.from) != "undefined" && credentials.from.indexOf(transaction.from) != -1){
+                amount+= transaction.value / Math.pow(10,18);
+              }
+            }
+            result.push(new Coin('ETH', amount, 'Etherscan'));
+          }));
+        }
+
+        return Promise.all(promises).then(()=>{
+          resolve(result);
+        });
+      }else{
         let addresses = credentials.addresses.join(',')
         let options = {
           uri: 'https://api.etherscan.io/api?module=account&action=balancemulti&address=' + encodeURIComponent(addresses),
@@ -28,6 +53,6 @@ export default class EtherscanWallet extends AbstractWallet {
             reject(err)
           })
       }
-    )
+    });
   }
 }


### PR DESCRIPTION
Can filter transactions from etherscan. Useful in case you have only one ether address but you want to only display amounts from specific senders.

Smoke Test

- Put your address/addresses in your config as you would normally
- Add a from attribute in the etherscan as an array 
- Add a list of addresses you want to filter

The final amount should reflect only the transactions of the addresses in the from array